### PR TITLE
feat: add support to yarn and allow package without custom output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Use `semantic-release-vsce` as part of `verifyConditions` and `publish`.
     ],
     "prepare": {
       "path": "semantic-release-vsce",
-      "packageVsix": "your-extension.vsix"
+      "packageVsix": true
     },
     "publish": [
       "semantic-release-vsce",
       {
         "path": "@semantic-release/github",
-        "assets": "your-extension.vsix"
+        "assets": "*.vsix"
       }
     ]
   },
@@ -43,7 +43,7 @@ Use `semantic-release-vsce` as part of `verifyConditions` and `publish`.
 }
 ```
 
-If `packageVsix` is set, will also generate a .vsix file at the set file path after publishing.
+If `packageVsix` is set, will also generate a .vsix file at the set file path after publishing. If is a string, it will be used as value for `--out` of `vsce package`.
 It is recommended to upload this to your GitHub release page so your users can easily rollback to an earlier version if a version ever introduces a bad bug. 
 
 If `yarn` is set to `true`, will use `--yarn`option for `vsce package` and `vsce publish`.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Use `semantic-release-vsce` as part of `verifyConditions` and `publish`.
 If `packageVsix` is set, will also generate a .vsix file at the set file path after publishing.
 It is recommended to upload this to your GitHub release page so your users can easily rollback to an earlier version if a version ever introduces a bad bug. 
 
+If `yarn` is set to `true`, will use `--yarn`option for `vsce package` and `vsce publish`.
+
 #### Working with older versions
 
 This example is for `semantic-release` v15.  

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ async function prepare (pluginConfig, { nextRelease: { version }, logger }) {
     await verifyVsce(logger);
     verified = true;
   }
-  await vscePrepare(version, pluginConfig.packageVsix, logger);
+  await vscePrepare(version, pluginConfig.packageVsix, pluginConfig.yarn, logger);
   prepared = true;
 }
 
@@ -27,9 +27,9 @@ async function publish (pluginConfig, { nextRelease: { version }, logger }) {
 
   if (!prepared) {
     // BC: prior to semantic-release v15 prepare was part of publish
-    await vscePrepare(version, pluginConfig.packageVsix, logger);
+    await vscePrepare(version, pluginConfig.packageVsix, pluginConfig.yarn, logger);
   }
-  return vscePublish(version, logger);
+  return vscePublish(version, pluginConfig.yarn, logger);
 }
 
 module.exports = {

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -7,8 +7,12 @@ module.exports = async (version, packageVsix, yarn, logger) => {
   if (packageVsix) {
     logger.log('Packaging version %s as .vsix', version);
     
-    let options = ['package', '--out', packageVsix]
-    
+    let options = ['package'];
+
+    if (typeof packageVsix === "string") {
+        options.concat(['--out', packageVsix])
+    }
+
     if (yarn) {
         options.push('--yarn')
     }

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -1,11 +1,18 @@
 const execa = require('execa');
 const updatePackageVersion = require('./update-package-version');
 
-module.exports = async (version, packageVsix, logger) => {
+module.exports = async (version, packageVsix, yarn, logger) => {
   await updatePackageVersion(version, logger);
 
   if (packageVsix) {
     logger.log('Packaging version %s as .vsix', version);
-    await execa('vsce', ['package', '--out', packageVsix], { stdio: 'inherit' });
+    
+    let options = ['package', '--out', packageVsix]
+    
+    if (yarn) {
+        options.push('--yarn')
+    }
+
+    await execa('vsce', options, { stdio: 'inherit' });
   }
 };

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,13 +1,20 @@
 const execa = require('execa');
 const { readJson } = require('fs-extra');
 
-module.exports = async (version, logger) => {
+module.exports = async (version, yarn, logger) => {
   const { VSCE_TOKEN } = process.env;
 
   const { publisher, name } = await readJson('./package.json');
 
   logger.log('Publishing version %s to vs code marketplace', version);
-  await execa('vsce', ['publish', '--pat', VSCE_TOKEN], { stdio: 'inherit' });
+  
+  let options = ['publish', '--pat', VSCE_TOKEN]
+  
+  if (yarn) {
+    options.push('--yarn')
+  }
+  
+  await execa('vsce', options, { stdio: 'inherit' });
 
   const url = `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`;
   logger.log(`New version is available at ${url}`);


### PR DESCRIPTION
Fixes https://github.com/raix/semantic-release-vsce/issues/60 and fixes https://github.com/raix/semantic-release-vsce/issues/63.